### PR TITLE
spelling error in "conditions"

### DIFF
--- a/sigma/pipelines/secops/postprocessing.py
+++ b/sigma/pipelines/secops/postprocessing.py
@@ -39,7 +39,7 @@ rule {rule.title.lower().replace(" ", "_")} {{
   events:
     {indented_query}
     
-  conditions: 
+  condition: 
     $event1
 }}
     """


### PR DESCRIPTION
I believe there was an error while writing the "conditions". Syntax documentation: https://cloud.google.com/chronicle/docs/detection/yara-l-2-0-syntax