### PR TITLE
Fix YARA-L 2.0 condition block keyword

### DIFF
--- a/sigma/pipelines/secops/postprocessing.py
+++ b/sigma/pipelines/secops/postprocessing.py
@@ -39,7 +39,7 @@ rule {rule.title.lower().replace(" ", "_")} {{
   events:
     {indented_query}
 
-  conditions:
+  condition:
     $event1
 }}
     """

--- a/tests/test_backend_secops.py
+++ b/tests/test_backend_secops.py
@@ -1,8 +1,8 @@
 import pytest
 
 from sigma.backends.secops import SecOpsBackend
-from sigma.collection import SigmaRule
 from sigma.pipelines.secops import secops_udm_pipeline
+from sigma.rule import SigmaRule
 
 
 @pytest.fixture
@@ -355,7 +355,7 @@ def test_secops_yara_l_output_format(secops_backend: SecOpsBackend):
     assert "rule test {" in output[0]
     assert "meta:" in output[0]
     assert "events:" in output[0]
-    assert "conditions:" in output[0]
+    assert "condition:" in output[0]
 
 
 def test_secops_or_grouping_regex_escaping(secops_backend: SecOpsBackend):


### PR DESCRIPTION
## Summary
  - Fixes `conditions:` → `condition:` in the YARA-L output template (`postprocessing.py`) — `conditions:` is not valid YARA-L 2.0 syntax
  - Updates the corresponding test assertion to match
  - Switches `test_backend_secops.py` to use the canonical `sigma.rule` import instead of `sigma.collection`

Fixes #3 