### PR TITLE
Skip unset optional YARA-L meta fields

### DIFF
--- a/sigma/pipelines/secops/postprocessing.py
+++ b/sigma/pipelines/secops/postprocessing.py
@@ -23,18 +23,31 @@ class YaraLPostprocessingTransformation(QueryPostprocessingTransformation):
         # Join the lines with proper indentation
         indented_query = "\n    ".join(query_lines)
 
+        meta_lines = [f'    title = "{rule.title}"']
+
+        if rule.id:
+            meta_lines.append(f'    id = "{rule.id}"')
+        if rule.description:
+            meta_lines.append(f'    description = "{rule.description}"')
+        if rule.author:
+            meta_lines.append(f'    author = "{rule.author}"')
+        if rule.references:
+            meta_lines.append(f'    reference = "{", ".join(rule.references)}"')
+        if rule.date:
+            meta_lines.append(f'    date = "{rule.date}"')
+        if rule.tags:
+            meta_lines.append(f'    tags = "{", ".join(str(tag) for tag in rule.tags)}"')
+        if rule.level:
+            meta_lines.append(f'    severity = "{rule.level}"')
+        if rule.falsepositives:
+            meta_lines.append(f'    falsepositives = "{", ".join(rule.falsepositives)}"')
+
+        meta_block = "\n".join(meta_lines)
+
         return f"""
 rule {rule.title.lower().replace(" ", "_")} {{
   meta:
-    id = "{rule.id}"
-    title = "{rule.title}"
-    description = "{rule.description}"
-    author = "{rule.author}"
-    reference = "{", ".join(rule.references)}"
-    date = "{rule.date}"
-    tags = "{", ".join(str(t) for t in rule.tags)}"
-    severity = "{rule.level}"
-    falsepositives = "{", ".join(rule.falsepositives) if rule.falsepositives else "Unknown"}"
+{meta_block}
 
   events:
     {indented_query}

--- a/tests/test_secops_postprocessing.py
+++ b/tests/test_secops_postprocessing.py
@@ -1,5 +1,6 @@
 from sigma.pipelines.secops.postprocessing import (
     PrependMetadataPostprocessingTransformation,
+    YaraLPostprocessingTransformation,
 )
 from sigma.processing.pipeline import ProcessingPipeline
 from sigma.rule import SigmaRule
@@ -16,23 +17,103 @@ def test_prepend_metadata_postprocessing():
             selection:
                 CommandLine: mimikatz.exe
             condition: selection
-    """
+        """
     )
 
-    # Add event types to rule
     rule.custom_attributes["event_types"] = {"PROCESS_LAUNCH", "PROCESS_TERMINATE"}
 
     pipeline = ProcessingPipeline()
     transform = PrependMetadataPostprocessingTransformation()
     transform._pipeline = pipeline
 
-    # Test default format
     result = transform.apply(rule, "target.process.command_line = mimikatz.exe")
     assert "metadata.event_type =" in result
     assert "AND" in result
 
-    # Test YARA-L format
     pipeline.state["output_format"] = "yara_l"
     result = transform.apply(rule, "target.process.command_line = mimikatz.exe")
     assert "$event1.metadata.event_type =" in result
     assert "OR" in result
+
+
+def test_yara_l_meta_omits_unset_optional_fields():
+    rule = SigmaRule.from_yaml(
+        """
+        title: Meta Omission Test
+        status: test
+        logsource:
+            category: process_creation
+            product: windows
+        detection:
+            sel:
+                CommandLine: valueA
+            condition: sel
+        """
+    )
+
+    pipeline = ProcessingPipeline()
+    pipeline.state["output_format"] = "yara_l"
+
+    transform = YaraLPostprocessingTransformation()
+    transform._pipeline = pipeline
+
+    result = transform.apply(rule, '$event1.target.process.command_line = "valueA"')
+
+    assert '    title = "Meta Omission Test"' in result
+    assert '= "None"' not in result
+    assert '    id =' not in result
+    assert '    description =' not in result
+    assert '    author =' not in result
+    assert '    reference =' not in result
+    assert '    date =' not in result
+    assert '    tags =' not in result
+    assert '    severity =' not in result
+    assert '    falsepositives =' not in result
+
+
+def test_yara_l_meta_preserves_set_optional_fields():
+    rule = SigmaRule.from_yaml(
+        """
+        title: Meta Complete Test
+        id: 11111111-1111-1111-1111-111111111111
+        status: test
+        description: Test description
+        author: Anwesh Mahapatra
+        references:
+            - https://example.com/ref1
+            - https://example.com/ref2
+        date: 2026-07-07
+        tags:
+            - attack.execution
+            - attack.t1059
+        level: high
+        falsepositives:
+            - Admin activity
+            - Testing
+        logsource:
+            category: process_creation
+            product: windows
+        detection:
+            sel:
+                CommandLine: valueA
+            condition: sel
+        """
+    )
+
+    pipeline = ProcessingPipeline()
+    pipeline.state["output_format"] = "yara_l"
+
+    transform = YaraLPostprocessingTransformation()
+    transform._pipeline = pipeline
+
+    result = transform.apply(rule, '$event1.target.process.command_line = "valueA"')
+
+    assert '    id = "11111111-1111-1111-1111-111111111111"' in result
+    assert '    title = "Meta Complete Test"' in result
+    assert '    description = "Test description"' in result
+    assert '    author = "Anwesh Mahapatra"' in result
+    assert '    reference = "https://example.com/ref1, https://example.com/ref2"' in result
+    assert '    date = "2026-07-07"' in result
+    assert '    tags = "attack.execution, attack.t1059"' in result
+    assert '    severity = "high"' in result
+    assert '    falsepositives = "Admin activity, Testing"' in result


### PR DESCRIPTION
## Summary

This PR updates YARA-L postprocessing so unset optional Sigma metadata fields are omitted from generated YARA-L output instead of being rendered as literal `"None"` or empty strings.

Before this change, rules without optional metadata could emit values such as:

- `id = "None"`
- `description = "None"`
- `author = "None"`
- `date = "None"`
- `tags = ""`
- `reference = ""`

The generated output now always includes `title`, while only emitting optional fields when they are actually set on the Sigma rule.

## Changes

- Builds the YARA-L `meta` block dynamically.
- Always emits `title`.
- Emits the following only when present:
  - `id`
  - `description`
  - `author`
  - `references`
  - `date`
  - `tags`
  - `level`
  - `falsepositives`
- Restores existing postprocessing test coverage.
- Adds tests for omitted and preserved YARA-L meta fields.

## Tests

Ran:

```bash
poetry run pytest tests/test_secops_postprocessing.py
poetry run pytest
git diff --check
```

Results:

```bash
tests/test_secops_postprocessing.py: 3 passed
Full test suite: 86 passed
git diff --check: passed
```

## Note
This PR intentionally does not address the conditions: → condition: YARA-L section keyword issue because that is already covered by #5

